### PR TITLE
Improve QoL for population management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /dev/
 *.bson
 models
+.mempool

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 CuArrays = "1, 2"
 MemPool = "0.2"
-NaiveNASflux = "1"
+NaiveNASflux = "1.2.1"
 Reexport = "0.2.0, 1"
 Setfield = "0.3.4, 0.5, 0.6"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,6 @@ version = "0.3.0"
 
 [deps]
 CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"
-FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 NaiveNASflux = "85610aed-7d32-5e57-bb50-4c2e1c9e7997"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -19,8 +17,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 CuArrays = "1, 2"
-FileIO = "1"
-JLD2 = "0.1.3, 1"
 NaiveNASflux = "1"
 Reexport = "0.2.0, 1"
 Setfield = "0.3.4, 0.5, 0.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,12 @@
 name = "NaiveGAflux"
 uuid = "81ede08e-ab29-11e9-16d3-79edd30a1d76"
 authors = ["DrChainsaw"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+MemPool = "f9f48841-c794-520a-933b-121f7ba6ed94"
 NaiveNASflux = "85610aed-7d32-5e57-bb50-4c2e1c9e7997"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -17,6 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 CuArrays = "1, 2"
+MemPool = "0.2"
 NaiveNASflux = "1"
 Reexport = "0.2.0, 1"
 Setfield = "0.3.4, 0.5, 0.6"

--- a/src/NaiveGAflux.jl
+++ b/src/NaiveGAflux.jl
@@ -13,10 +13,6 @@ using Setfield
 # For temporary storage of program state for pause/resume type of operations
 using Serialization
 
-# For longer term storage of models
-using FileIO
-using JLD2
-
 const rng_default = Random.GLOBAL_RNG
 const modeldir = "models"
 
@@ -33,7 +29,7 @@ export evolve!, AbstractEvolution, NoOpEvolution, AfterEvolution, ResetAfterEvol
 export Probability, MutationShield, ApplyIf, RemoveIfSingleInput, RepeatPartitionIterator, SeedIterator, MapIterator, GpuIterator, BatchIterator, FlipIterator, ShiftIterator, ShuffleIterator, PersistentArray, ShieldedOpt
 
 # Persistence
-export persist, savemodels
+export persist
 
 # Vertex selection types
 export AbstractVertexSelection, AllVertices, FilterMutationAllowed

--- a/src/NaiveGAflux.jl
+++ b/src/NaiveGAflux.jl
@@ -14,7 +14,7 @@ using Setfield
 # For temporary storage of program state for pause/resume type of operations
 using Serialization
 
-const rng_default = Random.GLOBAL_RNG
+const rng_default = MersenneTwister(abs(rand(Int)))
 const modeldir = "models"
 
 # Fitness

--- a/src/NaiveGAflux.jl
+++ b/src/NaiveGAflux.jl
@@ -7,6 +7,7 @@ using Random
 using Logging
 using Statistics
 using CuArrays
+import MemPool
 
 using Setfield
 

--- a/src/NaiveGAflux.jl
+++ b/src/NaiveGAflux.jl
@@ -25,6 +25,9 @@ export evolvemodel, AbstractCandidate, CandidateModel, HostCandidate, CacheCandi
 # Evolution
 export evolve!, AbstractEvolution, NoOpEvolution, AfterEvolution, ResetAfterEvolution, EliteSelection, SusSelection, TournamentSelection, CombinedEvolution, EvolveCandidates
 
+# Population
+export Population, generation
+
 # misc types
 export Probability, MutationShield, ApplyIf, RemoveIfSingleInput, RepeatPartitionIterator, SeedIterator, MapIterator, GpuIterator, BatchIterator, FlipIterator, ShiftIterator, ShuffleIterator, PersistentArray, ShieldedOpt
 
@@ -64,6 +67,7 @@ include("mutation.jl")
 include("fitness.jl")
 include("candidate.jl")
 include("evolve.jl")
+include("population.jl")
 include("iterators.jl")
 include("app/AutoFlux.jl")
 include("visualize/callbacks.jl")

--- a/src/app/imageclassification/ImageClassification.jl
+++ b/src/app/imageclassification/ImageClassification.jl
@@ -20,19 +20,22 @@ include("archspace.jl")
 
 """
     ImageClassifier
-    ImageClassifier(popsize, seed, newpop)
+    ImageClassifier(popinit, seed)
     ImageClassifier(;popsize=50, seed=1, newpop=false)
 
 Type to make `AutoFlux.fit` train an image classifier using initial population size `popsize` using random seed `seed`.
 
 If `newpop` is `true` the process will start with a new population and existing state in the specified directory will be overwritten.
 """
-struct ImageClassifier
+struct ImageClassifier{F}
+    popinit::F
     popsize::Int
     seed::Int
-    newpop::Bool
 end
-ImageClassifier(;popsize=50, seed=1, newpop=false) = ImageClassifier(popsize, seed, newpop)
+function ImageClassifier(;popsize=50, seed=1, newpop=false)
+    popinit = (mdir, fitnessgen, insize, outsize) -> generate_persistent(popsize, newpop, mdir, fitnessgen, insize, outsize)
+    return ImageClassifier(popinit, popsize, seed)
+end
 
 """
     fit(c::ImageClassifier, x, y; cb, fitnesstrategy, trainstrategy, evolutionstrategy, mdir)
@@ -92,7 +95,7 @@ function AutoFlux.fit(c::ImageClassifier, fit_iter, fitnessgen, evostrategy::Abs
 
     insize, outsize = datasize(fit_iter)
 
-    population = initial_models(c.popsize, mdir, c.newpop, fitnessgen, insize, outsize[1])
+    population = c.popinit(mdir, fitnessgen, insize, outsize[1])
 
     # If experiment was resumed we should start by evolving as population is persisted right before evolution
     if all(i -> isfile(NaiveGAflux.filename(population, i)), 1:length(population))
@@ -126,19 +129,20 @@ function evolutionloop(population, evostrategy, trainingiter, cb)
     return population
 end
 
-function initial_models(nr, mdir, newpop, fitnessgen, insize, outsize)
+function generate_persistent(nr, newpop, mdir, fitnessgen, insize, outsize, cwrap=HostCandidate, archspace = initial_archspace(insize[1:2], outsize))
     if newpop
         rm(mdir, force=true, recursive=true)
     end
 
     iv(i) = inputvertex(join(["model", i, ".input"]), insize[3], FluxConv{2}())
-    as = initial_archspace(insize[1:2], outsize)
-    return PersistentArray(mdir, nr, i -> create_model(join(["model", i]), as, iv(i), fitnessgen))
+    return PersistentArray(mdir, nr, i -> create_model(join(["model", i]), archspace, iv(i), fitnessgen, cwrap))
 end
-function create_model(name, as, in, fg)
+function create_model(name, as, in, fg, cwrap)
     optselect = optmutation(1.0)
     opt = optselect(Descent(rand() * 0.099 + 0.01))
-    CacheCandidate(HostCandidate(CandidateModel(CompGraph(in, as(name, in)), opt, Flux.logitcrossentropy, fg())))
+    # Always cache even if not strictly needed for all fitnessfunctions because consequence is so bad if one forgets
+    # it when needed. Users who know what they are doing can unwrap if caching is not wanted.
+    CacheCandidate(cwrap(CandidateModel(CompGraph(in, as(name, in)), opt, Flux.logitcrossentropy, fg())))
 end
 
 end

--- a/src/app/imageclassification/ImageClassification.jl
+++ b/src/app/imageclassification/ImageClassification.jl
@@ -98,9 +98,7 @@ function AutoFlux.fit(c::ImageClassifier, fit_iter, fitnessgen, evostrategy::Abs
     population = c.popinit(mdir, fitnessgen, insize, outsize[1])
 
     # If experiment was resumed we should start by evolving as population is persisted right before evolution
-    if all(i -> isfile(NaiveGAflux.filename(population, i)), 1:length(population))
-        population = evolve!(evostrategy, population)
-    end
+    population = generation(population) > 1 ? evolve!(evostrategy, population) : population
 
     return evolutionloop(population, evostrategy, fit_iter, cb)
 end
@@ -110,8 +108,8 @@ datasize(t::Tuple) = datasize.(t)
 datasize(a::AbstractArray) = size(a)
 
 function evolutionloop(population, evostrategy, trainingiter, cb)
-    for (gen, iter) in enumerate(trainingiter)
-        @info "Begin generation $gen"
+    for iter in trainingiter
+        @info "Begin generation $(generation(population))"
 
         for (i, cand) in enumerate(population)
             @info "\tTrain candidate $i with $(nv(NaiveGAflux.graph(cand))) vertices"
@@ -135,7 +133,7 @@ function generate_persistent(nr, newpop, mdir, fitnessgen, insize, outsize, cwra
     end
 
     iv(i) = inputvertex(join(["model", i, ".input"]), insize[3], FluxConv{2}())
-    return PersistentArray(mdir, nr, i -> create_model(join(["model", i]), archspace, iv(i), fitnessgen, cwrap))
+    return Population(PersistentArray(mdir, nr, i -> create_model(join(["model", i]), archspace, iv(i), fitnessgen, cwrap)))
 end
 function create_model(name, as, in, fg, cwrap)
     optselect = optmutation(1.0)

--- a/src/app/imageclassification/strategy.jl
+++ b/src/app/imageclassification/strategy.jl
@@ -181,7 +181,7 @@ function trainiter(s::TrainStrategy, x, y)
     return Iterators.cycle(partiter, s.nepochs)
 end
 
-batch(x, batchsize, seed) = ShuffleIterator(x, batchsize, MersenneTwister(seed))
+batch(x, batchsize, seed) = ShuffleIterator(NaiveGAflux.Singleton(x), batchsize, MersenneTwister(seed))
 dataiter(x,y::AbstractArray{T, 1}, bs, s, wrap) where T = zip(wrap(batch(x, bs, s)), Flux.onehotbatch(batch(y, bs, s), sort(unique(y))))
 dataiter(x,y::AbstractArray{T, 2}, bs, s, wrap) where T = zip(wrap(batch(x, bs, s)), batch(y, bs, s))
 

--- a/src/candidate.jl
+++ b/src/candidate.jl
@@ -14,33 +14,6 @@ function reset!(c::AbstractCandidate) end
 Base.Broadcast.broadcastable(c::AbstractCandidate) = Ref(c)
 
 """
-    savemodels(pop::AbstractArray{<:AbstractCandidate}, dir)
-    savemodels(pop::PersistentArray{<:AbstractCandidate})
-
-Save models (i.e. `CompGraph`s) of the given array of `AbstractCandidate`s in JLD2 format in directory `dir` (will be created if not existing).
-
-If `pop` is a `PersistentArray` and no directory is given models will be saved in `pop.savedir/models`.
-
-More suitable for long term storage compared to persisting the candidates themselves.
-"""
-function savemodels(pop::AbstractArray{<:AbstractCandidate}, dir)
-    mkpath(dir)
-    for (i, cand) in enumerate(pop)
-        model = graph(cand)
-        FileIO.save(joinpath(dir, "$i.jld2"), "model$i", cand |> cpu)
-    end
-end
-savemodels(pop::PersistentArray{<:AbstractCandidate}) = savemodels(pop, joinpath(pop.savedir, "models"))
-"""
-    savemodels(dir::AbstractString)
-
-Return a function which accepts an argument `pop` and calls `savemodels(pop, dir)`.
-
-Useful for callbacks to `AutoFlux.fit`.
-"""
-savemodels(dir::AbstractString) = pop -> savemodels(pop,dir)
-
-"""
     CandidateModel <: Candidate
     CandidateModel(model::CompGraph, optimizer, lossfunction, fitness::AbstractFitness)
 

--- a/src/candidate.jl
+++ b/src/candidate.jl
@@ -124,8 +124,8 @@ function callcand(f, c::FileCandidate, args...)
     return ret
 end
 
-# Mutation must be enabled here, so don't want to call movetodisk
-Flux.functor(c::FileCandidate) = Flux.functor(MemPools.poolget(c.c[]))
+# Mutation needs to be enabled here?
+Flux.functor(c::FileCandidate) = callcand(Flux.functor, c)
 
 Flux.train!(c::FileCandidate, data) = callcand(Flux.train!, c, data)
 fitness(c::FileCandidate) = callcand(fitness, c)

--- a/src/candidate.jl
+++ b/src/candidate.jl
@@ -201,6 +201,7 @@ function clearstate(s) end
 clearstate(s::AbstractDict) = foreach(k -> delete!(s, k), keys(s))
 
 cleanopt(o::T) where T = foreach(fn -> clearstate(getfield(o, fn)), fieldnames(T))
+cleanopt(o::ShieldedOpt) = cleanopt(o.opt)
 cleanopt(o::Flux.Optimiser) = foreach(cleanopt, o.os)
 cleanopt(c::CandidateModel) = cleanopt(c.opt)
 cleanopt(c::FileCandidate) = callcand(cleanopt, c.c)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -195,6 +195,7 @@ function Base.iterate(itr::BatchIterator, start=1)
 end
 
 ## I *think* speed matters here, so...
+batch(s::Singleton, start, stop) = batch(val(s), start, stop)
 batch(a::AbstractArray{T,1}, start, stop) where T = view(a, start:stop)
 batch(a::AbstractArray{T,2}, start, stop) where T = view(a, :,start:stop)
 batch(a::AbstractArray{T,3}, start, stop) where T = view(a, :,:,start:stop)
@@ -218,7 +219,7 @@ Flux.onehotbatch(itr::BatchIterator, labels) = MapIterator(x -> Flux.onehotbatch
 
 Beware: The data is shuffled in place. Provide a copy if the unshuffled data is also needed.
 """
-struct ShuffleIterator{T<:AbstractArray, R<:AbstractRNG}
+struct ShuffleIterator{T, R<:AbstractRNG}
     base::BatchIterator{T}
     rng::R
 end
@@ -237,6 +238,7 @@ end
 Base.iterate(itr::ShuffleIterator, state) = iterate(itr.base, state)
 
 ## I *think* speed matters here, so...
+shufflelastdim!(rng, s::Singleton) = shufflelastdim!(rng, val(s))
 shufflelastdim!(rng, a::AbstractArray{T,1}) where T = a[:] = a[randperm(rng, size(a,1))]
 shufflelastdim!(rng, a::AbstractArray{T,2}) where T = a[:,:] = a[:, randperm(rng, size(a, 2))]
 shufflelastdim!(rng, a::AbstractArray{T,3}) where T = a[:,:,:] = a[:,:, randperm(rng, size(a, 3))]

--- a/src/mutation.jl
+++ b/src/mutation.jl
@@ -542,7 +542,7 @@ NaiveNASflux.neuron_value(::Immutable, v) = ones(nout(v))
 NaiveNASflux.neuron_value(::MutationSizeTrait, v) = clean_values(cpu(neuron_value(v)),v)
 clean_values(::Missing, v) = ones(nout_org(v))
 # NaN should perhaps be < 0, but since SelectDirection is used, this might lead to inconsistent results as a subset of neurons for a vertex v whose output vertices are not part of the selection (typically because only v's inputs are touched) are selected. As the output vertices are not changed this will lead to a size inconsistency. Cleanest fix might be to separate "touch output" from "touch input" when formulating the output selection problem.
-clean_values(a::AbstractArray, v) = replace(a, NaN => 0.0001, 0.0 => 0.0001, Inf => 0.0001, -Inf => 0.0001)
+clean_values(a::AbstractArray{T}, v, repval=eps(T)) where T <: AbstractFloat = replace(a, NaN => repval, 0.0 => repval, Inf => repval, -Inf => repval)
 
 
 """

--- a/src/mutation.jl
+++ b/src/mutation.jl
@@ -682,7 +682,7 @@ learningrate(o::ShieldedOpt) = learningrate(o.opt)
 learningrate(o) = o.eta
 
 newlr(o, lrf = nudgelr) = sameopt(o, lrf(learningrate(o)))
-sameopt(::T, lr) where T = T(lr)
+sameopt(o, lr) = @set o.eta = lr
 
 """
     AddOptimizerMutation{F} <: AbstractMutation{FluxOptimizer}

--- a/src/population.jl
+++ b/src/population.jl
@@ -18,6 +18,7 @@ Base.size(p::AbstractPopulation) = size(wrappedpop(p))
 Base.IteratorSize(p::AbstractPopulation) = Base.IteratorSize(wrappedpop(p))
 Base.IteratorEltype(p::AbstractPopulation) = Base.IteratorEltype(wrappedpop(p))
 
+generation_filename(dir) = joinpath(dir, "generation.txt")
 
 """
     struct Population{N, P}
@@ -28,13 +29,25 @@ Basic population type which just adds generation counting to its members.
 
 Evolving the population returns a new `Population` with the generation counter incremented.
 """
-struct Population{N, P} <: AbstractPopulation
+struct Population{N<:Integer, P} <: AbstractPopulation
     gen::N
     members::P
 end
 Population(members) = Population(1, members)
+Population(members::PersistentArray) = Population(members.savedir, members)
+function Population(savedir::AbstractString, members)
+    gfile = generation_filename(savedir)
+    gen = !isfile(gfile) ? 1 : parse(Int, readline(gfile))
+    return Population(gen, members)
+end
+
 wrappedpop(p::Population) = p.members
 
 generation(p::Population) = p.gen
 
 evolve!(e::AbstractEvolution, p::Population) = Population(p.gen + 1, evolve!(e, wrappedpop(p)))
+
+function persist(p::Population{N, <:PersistentArray}) where N
+    persist(wrappedpop(p))
+    open(io -> write(io, string(p.gen)), generation_filename(wrappedpop(p).savedir); write=true)
+end

--- a/src/population.jl
+++ b/src/population.jl
@@ -1,0 +1,40 @@
+
+"""
+    AbstractPopulation
+
+Abstract base type for population.
+
+Keeps track of which generation it is and allows for iterating over its members.
+"""
+abstract type AbstractPopulation end
+
+generation(p::AbstractPopulation) = generation(b.base)
+
+Base.iterate(p::AbstractPopulation, s...) = Base.iterate(wrappedpop(p), s...)
+
+Base.length(p::AbstractPopulation) = length(wrappedpop(p))
+Base.eltype(p::AbstractPopulation) = eltype(wrappedpop(p))
+Base.size(p::AbstractPopulation) = size(wrappedpop(p))
+Base.IteratorSize(p::AbstractPopulation) = Base.IteratorSize(wrappedpop(p))
+Base.IteratorEltype(p::AbstractPopulation) = Base.IteratorEltype(wrappedpop(p))
+
+
+"""
+    struct Population{N, P}
+    Population(gen, members)
+    Population(members)
+
+Basic population type which just adds generation counting to its members.
+
+Evolving the population returns a new `Population` with the generation counter incremented.
+"""
+struct Population{N, P} <: AbstractPopulation
+    gen::N
+    members::P
+end
+Population(members) = Population(1, members)
+wrappedpop(p::Population) = p.members
+
+generation(p::Population) = p.gen
+
+evolve!(e::AbstractEvolution, p::Population) = Population(p.gen + 1, evolve!(e, wrappedpop(p)))

--- a/src/util.jl
+++ b/src/util.jl
@@ -257,16 +257,16 @@ struct Singleton{T}
     val::T
     function Singleton(val::T) where T
         s = new{T}(val)
-        singletons[val] = WeakRef(s)
+        singletons[val] = s
         return s
     end
 end
 val(s::Singleton) = s.val
 
-const singletons = WeakKeyDict{Any, WeakRef}()
+const singletons = WeakKeyDict()
 function Serialization.deserialize(s::AbstractSerializer, ::Type{Singleton{T}}) where T
     val = deserialize(s)
-    return get!(()-> WeakRef(Singleton(val)), singletons, val).value
+    return get!(()-> Singleton(val), singletons, val)
 end
 
 Base.deepcopy_internal(s::Singleton, stackdict::IdDict) = s

--- a/src/util.jl
+++ b/src/util.jl
@@ -193,9 +193,6 @@ Shields `o` from mutation by `OptimizerMutation`.
 """
 struct ShieldedOpt{O}
     opt::O
-
-    ShieldedOpt(o::O) where O = new{O}(o)
-    ShieldedOpt{O}(args...) where O = new{O}(O(args...))
 end
 Flux.Optimise.apply!(o::ShieldedOpt, args...) = Flux.Optimise.apply!(o.opt, args...)
 
@@ -214,7 +211,8 @@ function mergeopts(t::Type{T}, os...) where T
 end
 mergeopts() = []
 mergeopts(t::Type{T}, os::T...) where T = [mergeopts(os...)]
-mergeopts(os::T...) where T = T(prod(learningrate.(os)))
+mergeopts(os...) = first(@set os[1].eta = (prod(learningrate.(os))))
+mergeopts(os::ShieldedOpt{T}...) where T = ShieldedOpt(mergeopts(map(o -> o.opt, os)...))
 mergeopts(os::WeightDecay...) = WeightDecay(mapreduce(o -> o.wd, *, os))
 
 """

--- a/src/util.jl
+++ b/src/util.jl
@@ -131,7 +131,7 @@ function persist(a::PersistentArray)
         serialize(filename(a, i), v)
     end
 end
-FileIO.filename(a::PersistentArray, i::Int) = joinpath(a.savedir, "$i$(a.suffix)")
+filename(a::PersistentArray, i::Int) = joinpath(a.savedir, "$i$(a.suffix)")
 Base.rm(a::PersistentArray; force=true, recursive=true) = rm(a.savedir, force=force, recursive=recursive)
 Base.rm(a::PersistentArray, i::Int, force=false, recursive=true) = rm(filename(a,i), force=force, recursive=recursive)
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -132,8 +132,13 @@ function persist(a::PersistentArray)
     end
 end
 filename(a::PersistentArray, i::Int) = joinpath(a.savedir, "$i$(a.suffix)")
-Base.rm(a::PersistentArray; force=true, recursive=true) = rm(a.savedir, force=force, recursive=recursive)
-Base.rm(a::PersistentArray, i::Int, force=false, recursive=true) = rm(filename(a,i), force=force, recursive=recursive)
+function Base.rm(a::PersistentArray; force=true, recursive=true)
+    foreach(i -> rm(a, i; force=force, recursive=recursive), 1:length(a))
+    if readdir(a.savedir) |> isempty
+        rm(a.savedir; force=force, recursive=recursive)
+    end
+end
+Base.rm(a::PersistentArray, i::Int; force=false, recursive=true) = rm(filename(a,i), force=force, recursive=recursive)
 
 Base.size(a::PersistentArray) = size(a.data)
 Base.getindex(a::PersistentArray, i::Int) = getindex(a.data, i)

--- a/src/util.jl
+++ b/src/util.jl
@@ -255,6 +255,11 @@ Also makes sure that only one unique copy of `val` is created when deserializing
 """
 struct Singleton{T}
     val::T
+    function Singleton(val::T) where T
+        s = new{T}(val)
+        singletons[val] = WeakRef(s)
+        return s
+    end
 end
 val(s::Singleton) = s.val
 

--- a/src/visualize/callbacks.jl
+++ b/src/visualize/callbacks.jl
@@ -141,6 +141,7 @@ function plotfitness(p::ScatterOpt, population)
 end
 
 opt(c::AbstractCandidate) = opt(c.c)
+opt(c::FileCandidate) = callcand(opt, c)
 opt(c::CandidateModel) = c.opt
 lr(o) = learningrate(o)
 ot(o::Flux.Optimiser) = ot(o.os[1])

--- a/src/visualize/callbacks.jl
+++ b/src/visualize/callbacks.jl
@@ -140,7 +140,7 @@ function plotfitness(p::ScatterOpt, population)
     plotgen(p)
 end
 
-opt(c::AbstractCandidate) = opt(c.c)
+opt(c::AbstractCandidate) = opt(wrappedcand(c))
 opt(c::FileCandidate) = callcand(opt, c)
 opt(c::CandidateModel) = c.opt
 lr(o) = learningrate(o)

--- a/test/candidate.jl
+++ b/test/candidate.jl
@@ -126,25 +126,6 @@
         end
     end
 
-    @testset "eagermutation" begin
-        invertex = inputvertex("in", 3, FluxDense())
-        hlayer = mutable("hlayer", Dense(3,4), invertex)
-        outlayer = mutable("outlayer", Dense(4, 2), hlayer)
-        graph = CompGraph(invertex, outlayer)
-
-        Δnout(hlayer, 2)
-        Δoutputs(hlayer, v -> ones(nout_org(v)))
-        apply_mutation(graph)
-
-        @test nout(layer(hlayer)) == 4
-        @test nin(layer(outlayer)) == 4
-
-        NaiveGAflux.eagermutation(graph)
-
-        @test nout(layer(hlayer)) == 6
-        @test nin(layer(outlayer)) == 6
-    end
-
     @testset "Global optimizer mutation" begin
         import NaiveGAflux.Flux.Optimise: Optimiser
         import NaiveGAflux: sameopt, learningrate, BoundedRandomWalk, global_optimizer_mutation, randomlrscale

--- a/test/candidate.jl
+++ b/test/candidate.jl
@@ -73,44 +73,6 @@
         @test nin(layer(outlayer)) == 6
     end
 
-    @testset "Save models" begin
-        testdir = "test_savemodels"
-
-        # Weird name to avoid collisions (e.g. MockCand is defined in another testset and therefore unusable)
-        struct SaveModelsCand <: AbstractCandidate
-            i
-        end
-        NaiveGAflux.graph(c::SaveModelsCand) = c.i
-
-        ndir = joinpath(testdir,"normal")
-        pdir = joinpath(testdir,"persistent")
-        cdir = joinpath(testdir,"curried")
-
-        normal = SaveModelsCand.(1:10)
-        persistent = PersistentArray(pdir, length(normal), i -> normal[i])
-
-        curried = savemodels(cdir)
-
-        filenames = map(i -> "$i.jld2", 1:length(normal))
-
-        try
-            savemodels(normal, ndir)
-            @test all(isfile.(joinpath.(ndir, filenames)))
-            rm(ndir, force=true, recursive=true)
-
-            savemodels(persistent)
-            @test all(isfile.(joinpath.(pdir, "models", filenames)))
-            rm(pdir, force=true, recursive=true)
-
-            curried(normal)
-            @test all(isfile.(joinpath.(cdir, filenames)))
-            rm(cdir, force=true, recursive=true)
-        finally
-            rm(testdir, force=true, recursive=true)
-        end
-    end
-
-
     @testset "Global optimizer mutation" begin
         import NaiveGAflux.Flux.Optimise: Optimiser
         import NaiveGAflux: sameopt, learningrate, BoundedRandomWalk, global_optimizer_mutation, randomlrscale

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -15,7 +15,7 @@
 
     # Sample 5 models from the initial search space
     models = [CompGraph(inshape, initial_searchspace(inshape)) for _ in 1:5]
-    @test nv.(models) == [3, 5, 3, 4, 3]
+    @test nv.(models) == [3, 4, 3, 5, 3]
 
     # Workaround as losses fail with Flux.OneHotMatrix on Appveyor x86
     onehot(y) = Float32.(Flux.onehotbatch(y, 1:nlabels))
@@ -153,11 +153,11 @@ end
 
     # Sample one architecture from the search space
     graph1 = CompGraph(inputshape, archspace(inputshape))
-    @test nv(graph1) == 64
+    @test nv(graph1) == 126
 
     # And one more...
     graph2 = CompGraph(inputshape, archspace(inputshape))
-    @test nv(graph2) == 50
+    @test nv(graph2) == 103
 end
 
 @testset "Mutation examples" begin
@@ -185,7 +185,7 @@ end
     mutation(graph)
 
     # Input vertex is never mutated
-    @test nout.(vertices(graph)) == [3,5,8]
+    @test nout.(vertices(graph)) == [3,5,4]
 
     # Use the MutationShield trait to protect vertices from mutation
     outlayer = mutable(Dense(nout(layer2), 10), layer2, traitfun = MutationShield)
@@ -193,21 +193,21 @@ end
 
     mutation(graph)
 
-    @test nout.(vertices(graph)) == [3,6,5,10]
+    @test nout.(vertices(graph)) == [3,4,3,10]
 
     # In most cases it makes sense to mutate with a certain probability
     mutation = VertexMutation(MutationProbability(NoutMutation(-0.5, 0.5), 0.5))
 
     mutation(graph)
 
-    @test nout.(vertices(graph)) == [3,7,5,10]
+    @test nout.(vertices(graph)) == [3,3,2,10]
 
     # Or just chose to either mutate the whole graph or don't do anything
-    mutation = MutationProbability(VertexMutation(NoutMutation(-0.5, 0.5)), 0.5)
+    mutation = MutationProbability(VertexMutation(NoutMutation(-0.5, 0.5)), 0.98)
 
     mutation(graph)
 
-    @test nout.(vertices(graph)) == [3,10,6,10]
+    @test nout.(vertices(graph)) == [3,4,3,10]
 
     # Up until now, size changes have only been kept track of, but not actually applied
     @test nout_org.(vertices(graph)) == [3,4,5,10]
@@ -215,7 +215,7 @@ end
     Δoutputs(graph, v -> ones(nout_org(v)))
     apply_mutation(graph)
 
-    @test nout.(vertices(graph)) == nout_org.(vertices(graph)) == [3,10,6,10]
+    @test nout.(vertices(graph)) == nout_org.(vertices(graph)) == [3,4,3,10]
     @test size(graph(ones(3,1))) == (10, 1)
 
     # NeuronSelectMutation keeps track of changed vertices and performs the above steps when invoked
@@ -223,20 +223,20 @@ end
 
     mutation(graph)
 
-    @test nout.(vertices(graph)) == [3,11,7,10]
-    @test nout_org.(vertices(graph)) == [3,10,6,10]
+    @test nout.(vertices(graph)) == [3,3,4,10]
+    @test nout_org.(vertices(graph)) == [3,4,3,10]
 
     select(mutation.m)
 
-    @test nout_org.(vertices(graph)) == [3,11,7,10]
+    @test nout_org.(vertices(graph)) == [3,3,4,10]
     @test size(graph(ones(3,1))) == (10, 1)
 
     # Mutation can also be conditioned:
-    mutation = VertexMutation(MutationFilter(v -> nout(v) < 8, RemoveVertexMutation()))
+    mutation = VertexMutation(MutationFilter(v -> nout(v) < 4, RemoveVertexMutation()))
 
     mutation(graph)
 
-    @test nout.(vertices(graph)) == [3,11,10]
+    @test nout.(vertices(graph)) == [3,4,10]
 
     # When adding vertices it is probably a good idea to try to initialize them as identity mappings
     addmut = AddVertexMutation(VertexSpace(DenseSpace(5, identity)), IdentityWeightInit())
@@ -254,7 +254,7 @@ end
 
     @test_logs (:info, "Selecting parameters...") mutation(graph)
 
-    @test nout.(vertices(graph)) == nout_org.(vertices(graph)) == [3,8,11,10]
+    @test nout.(vertices(graph)) == nout_org.(vertices(graph)) == [3,2,4,10]
 end
 
 @testset "Fitness functions" begin
@@ -425,7 +425,7 @@ end
     optimizer(c::CandidateModel) = typeof(c.opt)
 
     @test optimizer(cachinghostcand) == ADAM
-    @test optimizer(evolvedcand) == Nesterov
+    @test optimizer(evolvedcand) == Momentum
 end
 
 @testset "Evolution strategies" begin

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -416,7 +416,7 @@ end
 
     evolvedcand = evofun(cachinghostcand)
 
-    @test typeof(evolvedcand) == typeof(cachinghostcand)
+    @test typeof(evolvedcand) <: CacheCandidate{<:HostCandidate{<:CandidateModel}}
 
     @test nout.(vertices(NaiveGAflux.graph(evolvedcand))) == [3, 4, 4]
     @test nout.(vertices(graph)) == [3, 3, 3]

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -68,6 +68,13 @@ end
     @test "biter: $itr" == "biter: BatchIterator(size=(2, 3, 4, 5), batchsize=2)"
 end
 
+@testset "BatchIterator singleton" begin
+    itr = BatchIterator(Singleton([1,3,5,7,9,11]), 2)
+    for (i, b) in enumerate(itr)
+        @test b == [1,3] .+ 4(i-1)
+    end
+end
+
 @testset "ShuffleIterator ndims $(length(dims))" for dims in ((5), (3,4), (2,3,4), (2,3,4,5), (2,3,4,5,6), (2,3,4,5,6,7))
     sitr = ShuffleIterator(collect(reshape(1:prod(dims),dims...)), 2, MersenneTwister(123))
     bitr = BatchIterator(collect(reshape(1:prod(dims),dims...)), 2)
@@ -79,4 +86,12 @@ end
         push!(nall, nb...)
     end
     @test sall == nall
+end
+
+@testset "ShuffleIterator singleton" begin
+    itr = ShuffleIterator(Singleton([1,3,5,7,9,11]), 2, MersenneTwister(123))
+    for b in itr
+        @test length(b) == 2
+    end
+    @test sort(vcat(collect(itr)...)) == [1,3,5,7,9,11]
 end

--- a/test/population.jl
+++ b/test/population.jl
@@ -1,0 +1,19 @@
+@testset "Population" begin
+
+    function test_interface(p, members)
+        test_iterator(p, members)
+
+        ep = evolve!(NoOpEvolution(), p)
+        test_iterator(ep, p)
+
+        @test generation(ep) == generation(p) + 1
+    end
+
+    function test_iterator(p1, p2)
+        @test length(p1) == length(p2)
+        @test size(p1) == size(p2)
+        @test collect(p1) == collect(p2)
+    end
+
+    test_interface(Population(1:10), 1:10)
+end

--- a/test/population.jl
+++ b/test/population.jl
@@ -16,4 +16,31 @@
     end
 
     test_interface(Population(1:10), 1:10)
+
+    @testset "Persistent pop" begin
+        testdir = "testPersistentPopulation"
+        mems = PersistentArray(testdir, 4, identity)
+        pop1 = Population(mems)
+        @test generation(pop1) == 1
+        pop2 = evolve!(NoOpEvolution(), pop1)
+        @test generation(pop2) == 2
+
+        try
+
+            persist(pop2)
+            pop2 = Population(mems)
+
+            @test generation(pop2) == 2
+
+            pop3 = evolve!(NoOpEvolution(), pop2)
+            @test generation(pop3) == 3
+
+            persist(pop3)
+            pop3 = Population(mems)
+
+            @test generation(pop3) == 3
+        finally
+            rm(testdir, force=true, recursive=true)
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,9 @@ using Test
     @info "Testing evolve"
     include("evolve.jl")
 
+    @info "Testing population"
+    include("population.jl")
+
     @info "Testing iterators"
     include("iterators.jl")
 

--- a/test/util.jl
+++ b/test/util.jl
@@ -205,6 +205,6 @@ end
 
         s1,s2  = deserialize.(io)
 
-        @test val(s1) === val(s2) == d
+        @test val(s1) === val(s2) === val(s)
     end
 end

--- a/test/util.jl
+++ b/test/util.jl
@@ -177,3 +177,34 @@ end
     @test om(NaiveGAflux.ShieldedOpt(Momentum())) == isopt
     @test om(Flux.Optimiser(Momentum(), Nesterov())) == isopt
 end
+
+@testset "Singleton" begin
+    import NaiveGAflux: Singleton, val
+    @testset "copy" begin
+        d = Ref("test")
+
+        s1 = Singleton(d)
+        s2 = Singleton(d)
+
+        @test val(s1) === val(s2)
+        @test deepcopy(val(s1)) !== deepcopy(val(s2))
+
+        @test val(deepcopy(s1)) === val(deepcopy(s2))
+        @test val(copy(s1)) === val(copy(s2))
+
+        @test unique(val.(deepcopy([s1,s2])))[] === unique(val.(deepcopy([s2,s1])))[]
+    end
+
+    @testset "Serialization" begin
+        using Serialization
+        d = [1,3,5]
+        s = Singleton(d)
+
+        io = (PipeBuffer(), PipeBuffer())
+        serialize.(io, Ref(s))
+
+        s1,s2  = deserialize.(io)
+
+        @test val(s1) === val(s2) == d
+    end
+end

--- a/test/visualization/callbacks.jl
+++ b/test/visualization/callbacks.jl
@@ -19,6 +19,7 @@
         NaiveGAflux.fitness(c::PlotTestCand) = c.fitness
 
         try
+            import MemPool
             @testset "PlotFitness" begin
 
                 p = PlotFitness((args...;kwargs...) -> [], testdir)
@@ -76,10 +77,19 @@
 
                 @test p2(PlotTestCand.(3:5, [30, 40, 50], [300, 400, 500]))
                 @test p2.data ==  [[1 99 Descent; 2 198 Descent; 3 297 ADAM], [2 198 Descent; 3 297 ADAM; 4 396 ADAM],[3 297 ADAM; 4 396 ADAM; 5 495 ADAM]]
+
+                p3 = ScatterOpt((args...;kwargs...) -> true, testdir)
+                @test p3(NaiveGAflux.FileCandidate.(PlotTestCand.(3:5, [30, 40, 50], [300, 400, 500])))
+                # Test that something was added
+                @test length(p3.data) == 1 + length(p2.data)
+                # What was added is just a copy paste of the last thing inserted to p2 so this lazy check works
+                @test p3.data[end] == p2.data[end]
+
             end
 
         finally
             rm(testdir, force=true, recursive=true)
+            MemPool.cleanup()
         end
 
         @testset "MultiPlot" begin


### PR DESCRIPTION
Main goal is to make it more streamlined to change search space, including injecting arbitrary models (e.g. a pretrained model).

Will also try to make it easier to build things which depend on how many generations have passed. This is ofc tracked within the evolution loop, but the generation number is not stored, so if the process is stopped and later resumed the counter will start at 1.

Also fixes #37 through MemPool
Hopefully fixes #43 as well through the added Singleton wrapper (which might be a bad idea in the end)
oh, and also fixes #32 