### PR TITLE
Reduce how often neuron value is computed by default in ImageClassification

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NaiveGAflux"
 uuid = "81ede08e-ab29-11e9-16d3-79edd30a1d76"
 authors = ["DrChainsaw"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"
@@ -19,7 +19,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 CuArrays = "1, 2"
 MemPool = "0.2"
-NaiveNASflux = "1.2.1"
+NaiveNASflux = "1.4.0"
 Reexport = "0.2.0, 1"
 Setfield = "0.3.4, 0.5, 0.6"
 julia = "1"

--- a/src/app/imageclassification/archspace.jl
+++ b/src/app/imageclassification/archspace.jl
@@ -1,6 +1,8 @@
 
 
-default_layerconf() = LayerVertexConf(ActivationContribution ∘ LazyMutable, NaiveGAflux.default_logging())
+ActivationContributionLow(l) = ActivationContribution(l, NeuronValueEvery(20))
+
+default_layerconf() = LayerVertexConf(ActivationContributionLow ∘ LazyMutable, NaiveGAflux.default_logging())
 function initial_archspace(inshape, outsize)
 
     layerconf = default_layerconf()
@@ -56,8 +58,8 @@ end
 function rep_fork_res(s, n, min_rp=1;loglevel=Logging.Debug)
     n == 0 && return s
 
-    resconf = VertexConf(outwrap = ActivationContribution, traitdecoration = MutationShield ∘ NaiveGAflux.default_logging())
-    concconf = ConcConf(ActivationContribution,  MutationShield ∘ NaiveGAflux.default_logging())
+    resconf = VertexConf(outwrap = ActivationContributionLow, traitdecoration = MutationShield ∘ NaiveGAflux.default_logging())
+    concconf = ConcConf(ActivationContributionLow,  MutationShield ∘ NaiveGAflux.default_logging())
 
     msgfun(v) = "Created $(name(v)), nin: $(nin(v)), nout: $(nout(v))"
 


### PR DESCRIPTION
Should alleviate cases of poor performance (low GPU utilization) of large models due to https://github.com/DrChainsaw/NaiveNASflux.jl/issues/54